### PR TITLE
ccdaxpathvalidators CRIGTT data model modifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
 			<version>1.2.17</version>
 		</dependency>
 		<dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.0</version>
+        </dependency>
+		<dependency>
 			<groupId>org.sitenv.vocabulary</groupId>
   			<artifactId>codevalidator-api</artifactId>
   			<version>1.0-SNAPSHOT</version>

--- a/src/main/java/org/sitenv/xml/validators/ccda/CcdaCodeValidator.java
+++ b/src/main/java/org/sitenv/xml/validators/ccda/CcdaCodeValidator.java
@@ -5,14 +5,10 @@ package org.sitenv.xml.validators.ccda;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
-
 import org.apache.log4j.Logger;
 import org.sitenv.vocabularies.constants.VocabularyConstants;
 import org.sitenv.vocabularies.data.CodeValidationResult;
@@ -139,24 +135,9 @@ public class CcdaCodeValidator {
 				result.setInformation(true);
 				result.setInfoMessage("Code validation attempt of code system that does not exist in service.");
 				
-				if (VocabularyConstants.CODE_SYSTEM_MAP.keySet() != null)
-				{
-					Set<String> values = new TreeSet<String>();
-					for (String key : VocabularyConstants.CODE_SYSTEM_MAP.keySet())
-					{
-						if (key != null)
-						{
-							values.add(VocabularyConstants.CODE_SYSTEM_MAP.get(key));
-						}
-					}
-					
-
-					if (values.size() > 0)
-					{
-						result.setExpectedValues(values);
-						result.setExpectedValuesType(CcdaValidatorExpectedValuesType.CODE_SYSTEMS_FOR_INVALID_CODE_SYSTEM);
-					}
-				}
+				result.setExpectedValues(VocabularyConstants.CODE_SYSTEM_NAMES.keySet());
+				result.setExpectedValuesType(CcdaValidatorExpectedValuesType.CODE_SYSTEMS_FOR_INVALID_CODE_SYSTEM);
+				
 				list.add(result);
 			}
 			

--- a/src/main/java/org/sitenv/xml/validators/ccda/CcdaCodeValidator.java
+++ b/src/main/java/org/sitenv/xml/validators/ccda/CcdaCodeValidator.java
@@ -135,7 +135,7 @@ public class CcdaCodeValidator {
 				result.setInformation(true);
 				result.setInfoMessage("Code validation attempt of code system that does not exist in service.");
 				
-				result.setExpectedValues(VocabularyConstants.CODE_SYSTEM_NAMES.keySet());
+				result.setExpectedValues(VocabularyConstants.CODE_SYSTEM_NAMES.values());
 				result.setExpectedValuesType(CcdaValidatorExpectedValuesType.CODE_SYSTEMS_FOR_INVALID_CODE_SYSTEM);
 				
 				list.add(result);

--- a/src/main/java/org/sitenv/xml/validators/ccda/CcdaValueSetCodeValidator.java
+++ b/src/main/java/org/sitenv/xml/validators/ccda/CcdaValueSetCodeValidator.java
@@ -3,14 +3,10 @@ package org.sitenv.xml.validators.ccda;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
-
 import org.apache.log4j.Logger;
 import org.sitenv.vocabularies.constants.VocabularyConstants;
 import org.sitenv.vocabularies.data.ValueSetValidationResult;
@@ -181,24 +177,9 @@ public class CcdaValueSetCodeValidator {
 				result.setInformation(true);
 				result.setInfoMessage("Value set code validation attempt for a value set that does not exist in service.");
 				
-				if (VocabularyConstants.CODE_SYSTEM_MAP.keySet() != null)
-				{
-					Set<String> values = new TreeSet<String>();
-					for (String key : VocabularyConstants.CODE_SYSTEM_MAP.keySet())
-					{
-						if (key != null)
-						{
-							values.add(VocabularyConstants.CODE_SYSTEM_MAP.get(key));
-						}
-					}
-					
-
-					if (values.size() > 0)
-					{
-						result.setExpectedValues(values);
-						result.setExpectedValuesType(CcdaValidatorExpectedValuesType.CODE_SYSTEMS_FOR_INVALID_CODE_SYSTEM);
-					}
-				}
+				result.setExpectedValues(VocabularyConstants.CODE_SYSTEM_NAMES.keySet());
+				result.setExpectedValuesType(CcdaValidatorExpectedValuesType.CODE_SYSTEMS_FOR_INVALID_CODE_SYSTEM);
+				
 				list.add(result);
 			}
 			
@@ -220,8 +201,6 @@ public class CcdaValueSetCodeValidator {
 		result.setRequestedCodeSystem(codeSystem);
 		result.setRequestedCodeSystemName(codeSystemName);
 		result.setRequestedDisplayName(displayName);
-		result.setBaseXpathExpression(baseExpression);
-		result.setBaseNodeIndex(baseNodeIndex);
 		result.setXpathExpression(expression);
 		result.setNodeIndex(nodeIndex);
 		result.setRequestedValueSet(valueSet);

--- a/src/main/java/org/sitenv/xml/validators/ccda/CcdaValueSetCodeValidator.java
+++ b/src/main/java/org/sitenv/xml/validators/ccda/CcdaValueSetCodeValidator.java
@@ -177,7 +177,7 @@ public class CcdaValueSetCodeValidator {
 				result.setInformation(true);
 				result.setInfoMessage("Value set code validation attempt for a value set that does not exist in service.");
 				
-				result.setExpectedValues(VocabularyConstants.CODE_SYSTEM_NAMES.keySet());
+				result.setExpectedValues(VocabularyConstants.CODE_SYSTEM_NAMES.values());
 				result.setExpectedValuesType(CcdaValidatorExpectedValuesType.CODE_SYSTEMS_FOR_INVALID_CODE_SYSTEM);
 				
 				list.add(result);


### PR DESCRIPTION
- Updated codevalidator usages to comply with latest changes.
- Fixed usage of code system names for expected values (caught my own bug, thankfully right away).